### PR TITLE
Allow Bower to use newer jQuery versions.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "tests"
   ],
   "dependencies": {
-    "jquery": "1.11.1",
+    "jquery": ">=1.11.1",
     "svgeezy": "~1.0.0",
     "bootstrap-sass-official": "~3.3.1",
     "respond": "~1.4.2"


### PR DESCRIPTION
As far as I can see there is nothing specific to jQuery 1.11.1 in the template (and Bower packages declare their version requirements anyway).
