### PR TITLE
Require at least middleman-minify-html 3.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "bourbon", "~>4.0.2"
 
 gem "oj" # faster JS compiles
 gem "therubyracer" # faster JS compiles
-gem "middleman-minify-html", "~>3.4.0"
+gem "middleman-minify-html", "~>3.4.1"
 gem "middleman-favicon-maker", "~>3.7" # needs ImageMagick (http://www.imagemagick.org/)
 gem "middleman-search_engine_sitemap"
 gem "middleman-dotenv", "~> 1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
     hitimes (1.2.2)
     hooks (0.4.0)
       uber (~> 0.0.4)
-    htmlcompressor (0.1.2)
+    htmlcompressor (0.2.0)
     i18n (0.6.11)
     json (1.8.1)
     kramdown (1.5.0)
@@ -85,8 +85,8 @@ GEM
     middleman-favicon-maker (3.7)
       favicon_maker (~> 1.3)
       middleman-core (>= 3.0.0)
-    middleman-minify-html (3.4.0)
-      htmlcompressor (~> 0.1.0)
+    middleman-minify-html (3.4.1)
+      htmlcompressor (~> 0.2.0)
       middleman-core (>= 3.2)
     middleman-search_engine_sitemap (1.3.0)
       builder
@@ -155,7 +155,7 @@ DEPENDENCIES
   middleman-deploy (~> 1.0)
   middleman-dotenv (~> 1.0)
   middleman-favicon-maker (~> 3.7)
-  middleman-minify-html (~> 3.4.0)
+  middleman-minify-html (~> 3.4.1)
   middleman-search_engine_sitemap
   oj
   slim (~> 3.0.0)


### PR DESCRIPTION
Earlier versions default to `remove_http_protocol: false` which breaks links to non-ssl sites if the middleman site is served via ssl.

See https://github.com/middleman/middleman-minify-html/issues/30 and https://github.com/middleman/middleman-minify-html/pull/32 for details.
